### PR TITLE
A Wizard of Tono向けの実装

### DIFF
--- a/contracts/BaseNFT.sol
+++ b/contracts/BaseNFT.sol
@@ -27,4 +27,11 @@ contract BaseNFT is IERC721AQueryable, ERC721AQueryable, Ownable {
     function _baseURI() internal view virtual override returns (string memory) {
         return _baseTokenURI;
     }
+
+    function bulkTransfer(address[] memory targets, uint256 startId) public virtual {
+        address owner = msg.sender;
+        for (uint i; i < targets.length; i++) {
+            transferFrom(owner, targets[i], startId + i);
+        }
+    }
 }

--- a/contracts/BorrowableWrapper.sol
+++ b/contracts/BorrowableWrapper.sol
@@ -27,7 +27,7 @@ contract BorrowableWrapper is IERC721, Ownable {
 
         require(tokenOwner != address(0), "No owner");
         require(borrower != address(0), "No borrower");
-        require(tokenOwner != owner(), "If the Token holder is Contract Owner, it cannot be lent.");
+        require(tokenOwner != 0x8AE5d42c55a9a5EcBbc917613b3174D158D78A6b, "If the Token holder is First Seller, it cannot be lent.");
         require(tokenOwner != borrower, "The lender and the borrower are the same person");
         require(_borrowers[tokenId] == address(0) || _borrowingLimits[borrower] < block.timestamp, "Someone has already borrowed");
         require(balanceOf(borrower) == 0, "Borrower has already owned or borrowed");


### PR DESCRIPTION
A Wizard of Tono NFT向けに以下を実装するが、プロジェクト特有の実装すぎて本体にはマージしない。

- Bulk Transfer
- 販売前のNFTを借りられないようにする