### PR TITLE
:beer: LendableWrapper

### DIFF
--- a/contracts/Borrowing.sol
+++ b/contracts/Borrowing.sol
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
 contract Borrowing {
     address _wrapper;
     mapping(uint256 => address) private _borrowers;

--- a/contracts/Borrowing.sol
+++ b/contracts/Borrowing.sol
@@ -1,0 +1,46 @@
+contract Borrowing {
+    address _wrapper;
+    mapping(uint256 => address) private _borrowers;
+    mapping(address => uint256) private _borrowingPeriodEnds;
+    mapping(uint256 => uint256) private _borrowingCount;
+    uint256 private _lendingPeriodMin;
+
+    constructor(address wrapper, uint256 lendingPeriodMin) {
+        _wrapper = wrapper;
+        _lendingPeriodMin = lendingPeriodMin;
+    }
+
+    modifier onlyWrapper() {
+        require(_wrapper == msg.sender, "Borrowing: caller is not the wrapper");
+        _;
+    }
+
+    function isBorrowed(address borrower, uint256 timestamp) public view virtual returns(bool) {
+        return _borrowingPeriodEnds[borrower] > timestamp;
+    }
+
+    function getBorrowingPeriodEnds(address borrower) public view virtual returns(uint256) {
+        return _borrowingPeriodEnds[borrower];
+    }
+
+    function getBorrower(uint256 tokenId) public view virtual returns(address) {
+        return _borrowers[tokenId];
+    }
+
+    function canBorrow(uint256 tokenId, uint256 timestamp) public view virtual returns(bool) {
+        address currentBorrower = getBorrower(tokenId);
+
+        return currentBorrower == address(0) || isBorrowed(currentBorrower, timestamp);
+    }
+
+    function borrowedCount(uint256 tokenId) public view virtual returns(uint256) {
+        return _borrowingCount[tokenId];
+    }
+
+    function setBorrower(uint256 tokenId, address borrower, uint256 timestamp) public virtual onlyWrapper {
+        uint256 periodEnd = timestamp + _lendingPeriodMin * 1 minutes;
+        _borrowers[tokenId] = borrower;
+        _borrowingPeriodEnds[borrower] = periodEnd;
+        _borrowingCount[tokenId]++;
+    }
+}

--- a/contracts/Borrowing.sol
+++ b/contracts/Borrowing.sol
@@ -6,11 +6,9 @@ contract Borrowing {
     mapping(uint256 => address) private _borrowers;
     mapping(address => uint256) private _borrowingPeriodEnds;
     mapping(uint256 => uint256) private _borrowingCount;
-    uint256 private _lendingPeriodMin;
 
-    constructor(address wrapper, uint256 lendingPeriodMin) {
+    constructor(address wrapper) {
         _wrapper = wrapper;
-        _lendingPeriodMin = lendingPeriodMin;
     }
 
     modifier onlyWrapper() {
@@ -40,8 +38,8 @@ contract Borrowing {
         return _borrowingCount[tokenId];
     }
 
-    function setBorrower(uint256 tokenId, address borrower, uint256 timestamp) public virtual onlyWrapper {
-        uint256 periodEnd = timestamp + _lendingPeriodMin * 1 minutes;
+    function setBorrower(uint256 tokenId, address borrower, uint64 expires) public virtual onlyWrapper {
+        uint256 periodEnd = expires;
         _borrowers[tokenId] = borrower;
         _borrowingPeriodEnds[borrower] = periodEnd;
         _borrowingCount[tokenId]++;

--- a/contracts/IERC4907.sol
+++ b/contracts/IERC4907.sol
@@ -1,0 +1,29 @@
+// SPDX-License-Identifier: CC0-1.0
+
+pragma solidity ^0.8.0;
+
+interface IERC4907 {
+    // Logged when the user of a NFT is changed or expires is changed
+    /// @notice Emitted when the `user` of an NFT or the `expires` of the `user` is changed
+    /// The zero address for user indicates that there is no user address
+    event UpdateUser(uint256 indexed tokenId, address indexed user, uint64 expires);
+
+    /// @notice set the user and expires of a NFT
+    /// @dev The zero address indicates there is no user
+    /// Throws if `tokenId` is not valid NFT
+    /// @param user  The new user of the NFT
+    /// @param expires  UNIX timestamp, The new user could use the NFT before expires
+    function setUser(uint256 tokenId, address user, uint64 expires) external;
+
+    /// @notice Get the user address of an NFT
+    /// @dev The zero address indicates that there is no user or the user is expired
+    /// @param tokenId The NFT to get the user address for
+    /// @return The user address for this NFT
+    function userOf(uint256 tokenId) external view returns(address);
+
+    /// @notice Get the user expires of an NFT
+    /// @dev The zero value indicates that there is no user
+    /// @param tokenId The NFT to get the user expires for
+    /// @return The user expires for this NFT
+    function userExpires(uint256 tokenId) external view returns(uint256);
+}

--- a/contracts/LendableWrapper.sol
+++ b/contracts/LendableWrapper.sol
@@ -25,8 +25,7 @@ contract LendableWrapper is IERC721, IERC4907, Ownable {
     function lend(uint256 tokenId, address borrower, uint64 expires) public virtual {
         address lender = msg.sender;
         address tokenOwner = _baseNft.ownerOf(tokenId);
-        address currentBorrower = _borrowing.getBorrower(tokenId);
-        uint256 now = block.timestamp;
+        uint256 currentTimestamp = block.timestamp;
 
         // check TokenOwner
         require(tokenOwner != address(0), "No owner");
@@ -41,8 +40,8 @@ contract LendableWrapper is IERC721, IERC4907, Ownable {
         require(balanceOf(borrower) == 0, "Borrower has already owned or borrowed");
 
         // check lendable
-        require(_borrowing.canBorrow(tokenId, now), "already borrowed");
-        require(now < expires, "wrong expires");
+        require(_borrowing.canBorrow(tokenId, currentTimestamp), "already borrowed");
+        require(currentTimestamp < expires, "wrong expires");
 
         _borrowing.setBorrower(tokenId, borrower, expires);
         emit Lend(borrower, tokenOwner, tokenId, _borrowing.getBorrowingPeriodEnds(borrower));

--- a/contracts/LendableWrapper.sol
+++ b/contracts/LendableWrapper.sol
@@ -43,7 +43,9 @@ contract LendableWrapper is IERC721, IERC4907, Ownable {
         require(currentTimestamp < expires, "wrong expires");
 
         _borrowing.setBorrower(tokenId, borrower, expires);
-        emit Lend(borrower, tokenOwner, tokenId, _borrowing.getBorrowingPeriodEnds(borrower));
+
+        emit Lend(borrower, tokenOwner, tokenId, expires);
+        emit UpdateUser(tokenId, borrower, expires);
     }
 
     function lentCount(uint256 tokenId) public view virtual returns (uint256) {
@@ -100,8 +102,6 @@ contract LendableWrapper is IERC721, IERC4907, Ownable {
     // ==============================
     function setUser(uint256 tokenId, address user, uint64 expires) external override {
         lend(tokenId, user, expires);
-
-        emit UpdateUser(tokenId,user,expires);
     }
 
     function userOf(uint256 tokenId) external view override returns(address) {

--- a/contracts/LendableWrapper.sol
+++ b/contracts/LendableWrapper.sol
@@ -2,7 +2,6 @@
 pragma solidity ^0.8.0;
 
 import "@openzeppelin/contracts/token/ERC721/IERC721.sol";
-import "erc721a/contracts/extensions/IERC721AQueryable.sol";
 import "@openzeppelin/contracts/access/Ownable.sol";
 import "./Borrowing.sol";
 import "./IERC4907.sol";
@@ -13,12 +12,12 @@ contract LendableWrapper is IERC721, IERC4907, Ownable {
     event Lend(address indexed borrower, address indexed owner, uint256 indexed tokenId, uint256 lendingPeriodEndTimestamp);
 
     Borrowing private _borrowing;
-    IERC721AQueryable private _baseNft;
+    IERC721 private _baseNft;
     address private _firstSeller;
 
     constructor(address baseNftAddress, address firstSeller) {
         _borrowing = new Borrowing(address(this));
-        _baseNft = IERC721AQueryable(baseNftAddress);
+        _baseNft = IERC721(baseNftAddress);
         _firstSeller = firstSeller;
     }
 
@@ -53,10 +52,6 @@ contract LendableWrapper is IERC721, IERC4907, Ownable {
 
     function canLend(uint256 tokenId, address borrower) public view virtual returns (bool) {
         return _borrowing.canBorrow(tokenId, block.timestamp) && balanceOf(borrower) == 0;
-    }
-
-    function totalSupply() external view returns (uint256) {
-        return _baseNft.totalSupply();
     }
 
     // ==============================

--- a/contracts/LendableWrapper.sol
+++ b/contracts/LendableWrapper.sol
@@ -9,7 +9,7 @@ import "./IERC4907.sol";
 contract LendableWrapper is IERC721, IERC4907, Ownable {
     error NotImplemented();
 
-    event Lend(address indexed borrower, address indexed owner, uint256 indexed tokenId, uint256 lendingPeriodEndTimestamp);
+    event Lend(address indexed borrower, address indexed owner, uint256 indexed tokenId, uint256 expires);
 
     Borrowing private _borrowing;
     IERC721 private _baseNft;

--- a/contracts/LendableWrapper.sol
+++ b/contracts/LendableWrapper.sol
@@ -1,0 +1,122 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+import "@openzeppelin/contracts/token/ERC721/IERC721.sol";
+import "erc721a/contracts/extensions/IERC721AQueryable.sol";
+import "@openzeppelin/contracts/access/Ownable.sol";
+import "./Borrowing.sol";
+
+contract LendableWrapper is IERC721, Ownable {
+    error NotImplemented();
+
+    event Lend(address indexed borrower, address indexed owner, uint256 indexed tokenId, uint256 lendingPeriodEndTimestamp);
+
+    Borrowing private _borrowing;
+    IERC721AQueryable private _baseNft;
+    address private _firstSeller;
+
+    constructor(address baseNftAddress, address firstSeller, uint256 lendingPeriodMin) {
+        _borrowing = new Borrowing(address(this), lendingPeriodMin);
+        _baseNft = IERC721AQueryable(baseNftAddress);
+        _firstSeller = firstSeller;
+    }
+
+    function lend(uint256 tokenId, address borrower) public virtual {
+        address lender = msg.sender;
+        address tokenOwner = _baseNft.ownerOf(tokenId);
+        address currentBorrower = _borrowing.getBorrower(tokenId);
+        uint256 now = block.timestamp;
+
+        // check TokenOwner
+        require(tokenOwner != address(0), "No owner");
+        require(tokenOwner != _firstSeller, "If the Token holder is first seller, it cannot be lent.");
+
+        // check Lender
+        require(lender != address(0), "No lender");
+        require(lender == tokenOwner, "Not owned by the lender.");
+        require(lender != borrower, "The lender and the borrower are the same person");
+
+        // check borrower
+        require(balanceOf(borrower) == 0, "Borrower has already owned or borrowed");
+
+        // check lendable
+        require(_borrowing.canBorrow(tokenId, now), "already borrowed");
+
+        _borrowing.setBorrower(tokenId, borrower, now);
+        emit Lend(borrower, tokenOwner, tokenId, _borrowing.getBorrowingPeriodEnds(borrower));
+    }
+
+    function lentCount(uint256 tokenId) public view virtual returns (uint256) {
+        return _borrowing.borrowedCount(tokenId);
+    }
+
+    function canLend(uint256 tokenId, address borrower) public view virtual returns (bool) {
+        return _borrowing.canBorrow(tokenId, block.timestamp) && balanceOf(borrower) == 0;
+    }
+
+    function totalSupply() external view returns (uint256) {
+        return _baseNft.totalSupply();
+    }
+
+    // ==============================
+    //            IERC721
+    // ==============================
+    function balanceOf(address owner) public view virtual override returns (uint256) {
+        if (_borrowing.isBorrowed(owner, block.timestamp)) {
+            return 1;
+        } else {
+            uint256 balance = 0;
+            uint256[] memory tokenIds = _baseNft.tokensOfOwner(owner);
+            for (uint i; i < tokenIds.length; i++) {
+                uint256 tokenId = tokenIds[i];
+                address borrower = _borrowing.getBorrower(tokenId);
+                if (borrower == address(0) || !_borrowing.isBorrowed(borrower, block.timestamp)) {
+                    balance++;
+                }
+            }
+            return balance;
+        }
+    }
+
+    function ownerOf(uint256 tokenId) external view override returns (address owner) {
+        return _baseNft.ownerOf(tokenId);
+    }
+
+    function safeTransferFrom(address, address, uint256, bytes calldata) external override {
+        revert NotImplemented();
+    }
+
+    function safeTransferFrom(address, address, uint256) external override {
+        revert NotImplemented();
+    }
+
+    function transferFrom(address, address, uint256) external override {
+        revert NotImplemented();
+    }
+
+    function approve(address, uint256) external override {
+        revert NotImplemented();
+    }
+
+
+    function setApprovalForAll(address, bool) external override {
+        revert NotImplemented();
+    }
+
+
+    function getApproved(uint256) external view override returns (address) {
+        revert NotImplemented();
+    }
+
+    function isApprovedForAll(address, address) external view override returns (bool) {
+        revert NotImplemented();
+    }
+
+    // ==============================
+    //            IERC165
+    // ==============================
+    function supportsInterface(bytes4 interfaceId) external view returns (bool) {
+        // ERC165 interface ID for ERC165 and ERC721.
+        return interfaceId == 0x01ffc9a7 || interfaceId == 0x80ac58cd;
+    }
+}

--- a/test/lendableWrapperTest.ts
+++ b/test/lendableWrapperTest.ts
@@ -1,0 +1,87 @@
+import { expect } from "chai";
+import { ethers } from "hardhat";
+import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/signers";
+import { Contract, ContractFactory } from "ethers";
+
+describe("LendableWrapper", function () {
+  let contractOwner: SignerWithAddress;
+  let firstSeller: SignerWithAddress;
+  let borrower00: SignerWithAddress;
+  let tokenHolder00: SignerWithAddress;
+  let tokenHolder01: SignerWithAddress;
+  let BaseNFT: ContractFactory;
+  let baseNFT: Contract;
+  let LWrapper: ContractFactory;
+  let lWrapper: Contract;
+
+  before(async () => {
+    [contractOwner, firstSeller, borrower00, tokenHolder00, tokenHolder01] =
+      await ethers.getSigners();
+  });
+
+  describe("Lender NFT", function () {
+    before(async () => {
+      BaseNFT = await ethers.getContractFactory("BaseNFT");
+      baseNFT = await BaseNFT.deploy(
+        "BaseNFT",
+        "BRRW",
+        "https://example.com/nfts/"
+      );
+      await baseNFT.deployed();
+
+      LWrapper = await ethers.getContractFactory("LendableWrapper");
+      lWrapper = await LWrapper.deploy(
+        baseNFT.address,
+        firstSeller.address,
+        1440
+      );
+      await lWrapper.deployed();
+
+      // mint
+      await (
+        await baseNFT.connect(contractOwner).mint(contractOwner.address, 5)
+      ).wait();
+
+      // transfer
+      const transfer1Tx = await baseNFT
+        .connect(contractOwner)
+        .transferFrom(contractOwner.address, tokenHolder00.address, 1);
+      await transfer1Tx.wait();
+    });
+
+    it("lend, transfer", async function () {
+      expect(await lWrapper.lentCount(1)).to.equal(0);
+
+      const borrow1Tx = await lWrapper
+        .connect(tokenHolder00)
+        .lend(1, borrower00.address);
+      await borrow1Tx.wait();
+
+      expect(await baseNFT.ownerOf(1)).to.equal(tokenHolder00.address);
+      expect(await baseNFT.balanceOf(borrower00.address)).to.equal(0);
+      expect(await baseNFT.balanceOf(tokenHolder00.address)).to.equal(1);
+
+      expect(await lWrapper.ownerOf(1)).to.equal(tokenHolder00.address);
+      expect(await lWrapper.balanceOf(borrower00.address)).to.equal(1);
+      expect(await lWrapper.balanceOf(tokenHolder00.address)).to.equal(0);
+      expect(await lWrapper.lentCount(1)).to.equal(1);
+
+      // transfer
+      const transfer1Tx = await baseNFT
+        .connect(tokenHolder00)
+        .transferFrom(tokenHolder00.address, tokenHolder01.address, 1);
+      await transfer1Tx.wait();
+
+      expect(await baseNFT.ownerOf(1)).to.equal(tokenHolder01.address);
+      expect(await baseNFT.balanceOf(borrower00.address)).to.equal(0);
+      expect(await baseNFT.balanceOf(tokenHolder00.address)).to.equal(0);
+      expect(await baseNFT.balanceOf(tokenHolder01.address)).to.equal(1);
+
+      expect(await lWrapper.ownerOf(1)).to.equal(tokenHolder01.address);
+      expect(await lWrapper.balanceOf(borrower00.address)).to.equal(1);
+      expect(await lWrapper.balanceOf(tokenHolder00.address)).to.equal(0);
+      expect(await lWrapper.balanceOf(tokenHolder01.address)).to.equal(0);
+      expect(await lWrapper.lentCount(1)).to.equal(1);
+    });
+  });
+});


### PR DESCRIPTION
Implement LendableWrapper that can be rented by specifying a person.

LendableWrapper adds the behavior of ERC4907 to the existing NFT that implements IERC721Queryable.

- Removed the dependency on BaseNFT and now depends on IERC721Queryable instead. 
- Independent Contract for borrowing records from Wrapper
- implement IERC4907
  - See: https://github.com/ethereum/EIPs/blob/master/EIPS/eip-4907.md

### TODO

- [x] Rethink the separation of Wrapper and Borrowing Contract
  - [x] Apply this mechanism to BorrowableWrapper after policy is finalized
- [ ] Add deploy commands
- [ ] Add documents
